### PR TITLE
Replace references to vanished isl server

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -53,6 +53,7 @@ jobs:
     needs: crosstool
     runs-on: ${{ matrix.host }}
     strategy:
+      fail-fast: false
       matrix:
         host: [
           "ubuntu-latest",

--- a/config-apl-gcc10.2-gdb8.3
+++ b/config-apl-gcc10.2-gdb8.3
@@ -585,7 +585,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-apl-gcc10.2-gdb9
+++ b/config-apl-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-apl-gcc7.3-gdb7.12.1
+++ b/config-apl-gcc7.3-gdb7.12.1
@@ -506,7 +506,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-apl-gcc8.1-gdb8.1
+++ b/config-apl-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-apl-gcc9.2-gdb8.3
+++ b/config-apl-gcc9.2-gdb8.3
@@ -567,7 +567,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-byt-gcc10.2-gdb9
+++ b/config-byt-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-byt-gcc7.3-gdb7.12.1
+++ b/config-byt-gcc7.3-gdb7.12.1
@@ -506,7 +506,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-byt-gcc8.1-gdb8.1
+++ b/config-byt-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-byt-gcc9.2-gdb8.3
+++ b/config-byt-gcc9.2-gdb8.3
@@ -567,7 +567,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-cnl-gcc10.2-gdb9
+++ b/config-cnl-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-cnl-gcc7.3-gdb7.12.1
+++ b/config-cnl-gcc7.3-gdb7.12.1
@@ -506,7 +506,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-cnl-gcc8.1-gdb8.1
+++ b/config-cnl-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-cnl-gcc9.2-gdb8.3
+++ b/config-cnl-gcc9.2-gdb8.3
@@ -567,7 +567,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-hky-gcc8.1-gdb8.1
+++ b/config-hky-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-hky-gcc9.2-gdb8.3
+++ b/config-hky-gcc9.2-gdb8.3
@@ -567,7 +567,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-hsw-gcc10.2-gdb9
+++ b/config-hsw-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-hsw-gcc7.3-gdb7.12.1
+++ b/config-hsw-gcc7.3-gdb7.12.1
@@ -506,7 +506,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-hsw-gcc8.1-gdb8.1
+++ b/config-hsw-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-hsw-gcc9.2-gdb8.3
+++ b/config-hsw-gcc9.2-gdb8.3
@@ -567,7 +567,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx-gcc10.2-gdb9
+++ b/config-imx-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx-gcc8.1-gdb8.1
+++ b/config-imx-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx-gcc9.2-gdb8.3
+++ b/config-imx-gcc9.2-gdb8.3
@@ -567,7 +567,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx8m-gcc10.2-gdb9
+++ b/config-imx8m-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx8m-gcc8.1-gdb8.1
+++ b/config-imx8m-gcc8.1-gdb8.1
@@ -505,7 +505,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_16_1 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx8m-gcc9.2-gdb8.3
+++ b/config-imx8m-gcc9.2-gdb8.3
@@ -565,7 +565,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-imx8ulp-gcc10.2-gdb9
+++ b/config-imx8ulp-gcc10.2-gdb9
@@ -661,7 +661,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-lx7hifi4-gcc10.2-gdb9
+++ b/config-lx7hifi4-gcc10.2-gdb9
@@ -665,7 +665,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-mt8195-gcc10.2-gdb9
+++ b/config-mt8195-gcc10.2-gdb9
@@ -661,7 +661,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-rn-gcc10.2-gdb9
+++ b/config-rn-gcc10.2-gdb9
@@ -661,7 +661,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/config-rn-gcc9.2-gdb8.3
+++ b/config-rn-gcc9.2-gdb8.3
@@ -581,7 +581,7 @@ CT_ISL_V_0_19=y
 # CT_ISL_V_0_15 is not set
 # CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.19"
-CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/packages/isl/package.desc
+++ b/packages/isl/package.desc
@@ -1,6 +1,6 @@
 repository='git git://repo.or.cz/isl.git'
 bootstrap='./autogen.sh'
-mirrors='http://isl.gforge.inria.fr'
+mirrors='https://libisl.sourceforge.io'
 relevantpattern='*.*|.'
 milestones='0.12 0.13 0.14 0.15 0.18'
 archive_formats='.tar.xz .tar.bz2 .tar.gz'


### PR DESCRIPTION
Replaced isl.gforge.inria.fr with the more stable gcc.gnu.org/pub/gcc/infrastructure.