### PR TITLE
Remove mac from the host matrix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -9,10 +9,7 @@ jobs:
     runs-on: ${{ matrix.host }}
     strategy:
       matrix:
-        host: [
-          "ubuntu-latest",
-          "macos-10.15",
-        ]
+        host: "ubuntu-latest"
     steps:
       - name: "clone"
         uses: actions/checkout@v2


### PR DESCRIPTION
Mac checks have been very consistently failing for a while and may not even be valid targets of interest for us anyway.  Making a minimal change to stay as close to the upstream workflow as possible.