### PR TITLE
Update CI Workflow to skip MacOS as a target

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         host: [
           "ubuntu-latest",
-          "macos-10.15",
         ]
     steps:
       - name: "clone"
@@ -57,7 +56,6 @@ jobs:
       matrix:
         host: [
           "ubuntu-latest",
-          "macos-10.15",
         ]
         sample: [
           "aarch64-unknown-linux-gnu",


### PR DESCRIPTION
The macOS checks have been continually failing.  Additionally, they may mostly be irrelevant targets for our purposes.

Made the minimum changes possible to stay close to upstream crosstool workflows.os